### PR TITLE
Fixing email anchor tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,8 +167,8 @@
     <dd>On GitHub and <a href="https://discord.com/invite/ZjZadyC7PK">on Discord</a></dd>
 
     <dt>How can the tiny corp work for me?</dt>
-    <dd>Email me, george@tinygrad.org. We are looking for contracts and sponsorships to improve various aspects of
-      tinygrad.</a></dd>
+    <dd>Email me, <a href="mailto:george@tinygrad.org">george@tinygrad.org</a>. We are looking for contracts and sponsorships to improve various aspects of
+      tinygrad.</dd>
 
     <dt>How can I work for the tiny corp?</dt>
     <dd>See <b>hiring</b> above. Contributions to <a href="https://github.com/tinygrad/tinygrad">tinygrad</a> on GitHub


### PR DESCRIPTION
Fixes email a tag under `How can the tiny corp work for me?`