### PR TITLE
Updated Github Stars stat

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
   <hr>
   <h2 id="tinygrad">tinygrad</h2>
   <p>We write and maintain <a href="https://github.com/tinygrad/tinygrad">tinygrad</a>, the fastest growing neural
-    network framework (over 23,000 GitHub stars)</p>
+    network framework (almost 30,000 GitHub stars)</p>
 
   <p>It's extremely simple, and breaks down the most <a
       href="https://github.com/tinygrad/tinygrad/blob/master/examples/llama.py">complex</a> <a


### PR DESCRIPTION
Super simple change to update the website. 

We can wait for the 30k stars to pass if we want to leave it as _over 30k_ instead. 